### PR TITLE
SL1SW-2927: SLX Baseboard: differentiate baseboards by gpio pins

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -50,7 +50,8 @@
     // - 53 for Baseboard SLX variant,
     // - 54 for CX variant and
     // - 55 for WX variant of baseboard
-    const uint8_t INFO_HW_TYPE = 50;
+    // - 51 left for old baseboard10(obsolete) with no ID pins grounded.
+    const uint8_t INFO_HW_TYPE = 51;
     const uint16_t MAX_PACKET_LENGTH = 255;
     #define NEEDS_ADDRESS_CHANGE 0
 #elif defined(BOARD_TYPE_prusa_smartled01)

--- a/Config.h
+++ b/Config.h
@@ -41,9 +41,16 @@
 #elif defined(BOARD_TYPE_prusa_xbuddy_extension)
 	const uint8_t INFO_HW_TYPE = 44;
     const uint16_t MAX_PACKET_LENGTH = 255;
-// Reserved INFO_HW_TYPE = 50 for BOARD_TYPE_prusa_slx_led_indv_bridge
-#elif defined(BOARD_TYPE_prusa_baseboard10)
-    const uint8_t INFO_HW_TYPE = 51;
+
+#elif defined(BOARD_TYPE_prusa_baseboard)
+    // Actual INFO_HW_TYPE is determined at runtime based on resistors
+    // connected to the GPIO pins of the baseboard. This will be
+    // a placeholder.
+    // Baseboard variants:
+    // - 53 for Baseboard SLX variant,
+    // - 54 for CX variant and
+    // - 55 for WX variant of baseboard
+    const uint8_t INFO_HW_TYPE = 50;
     const uint16_t MAX_PACKET_LENGTH = 255;
     #define NEEDS_ADDRESS_CHANGE 0
 #elif defined(BOARD_TYPE_prusa_smartled01)

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ ifeq ($(ARCH),stm32-f4hal)
     CXXFLAGS          += -DUSE_FULL_LL_DRIVER
     ifeq ($(BOARD_TYPE), prusa_smartled01)
         CXXFLAGS      += -DFIXED_ADDRESS=3
-    else ifeq ($(BOARD_TYPE), prusa_baseboard10)
+    else ifeq ($(BOARD_TYPE), prusa_baseboard)
         CXXFLAGS      += -DFIXED_ADDRESS=2
 	else
 		$(error unknown f4 board")
@@ -277,7 +277,7 @@ endif
 # hw revisions without needing an explicit clean in between.
 .INTERMEDIATE: $(OBJ) $(EXTRA_OBJ)
 
-all: dwarf modularbed xbuddy_extension prusa_baseboard10 prusa_smartled01
+all: dwarf modularbed xbuddy_extension prusa_baseboard prusa_smartled01
 
 dwarf:
 	$(MAKE) firmware ARCH=stm32-ocm3 BUS=Rs485 BOARD_TYPE=prusa_dwarf CURRENT_HW_REVISION=0x10 COMPATIBLE_HW_REVISION=0x10
@@ -297,11 +297,12 @@ modularbed_debug:
 xbuddy_extension_debug:
 	$(MAKE) firmware DEBUG=1 ARCH=stm32-h5hal BUS=Rs485 BOARD_TYPE=prusa_xbuddy_extension CURRENT_HW_REVISION=0x10 COMPATIBLE_HW_REVISION=0x10
 
-baseboard10:
-	$(MAKE) firmware DEBUG=1 ARCH=stm32-f4hal BUS=Rs485 BOARD_TYPE=prusa_baseboard10 CURRENT_HW_REVISION=0x10 COMPATIBLE_HW_REVISION=0x10
-
 smartled01:
 	$(MAKE) firmware DEBUG=1 ARCH=stm32-f4hal BUS=Rs485 BOARD_TYPE=prusa_smartled01 CURRENT_HW_REVISION=0x10 COMPATIBLE_HW_REVISION=0x10
+
+baseboard:
+	$(MAKE) firmware DEBUG=1 ARCH=stm32-f4hal BUS=Rs485 BOARD_TYPE=prusa_baseboard CURRENT_HW_REVISION=0x10 COMPATIBLE_HW_REVISION=0x10
+
 firmware: hex fuses size checksize
 
 hex: $(FILE_NAME).hex

--- a/bootloader.cpp
+++ b/bootloader.cpp
@@ -145,7 +145,7 @@ static cmd_result handleWriteFlash(uint32_t address, uint8_t *data, uint16_t len
 	}
 
 	// This guarantees that writes are aligned to the erase page size(==sizeof(writeBuffer))
-	if (address % sizeof(writeBuffer) == 0 && nextWriteAddress % sizeof(writeBuffer) == 0)
+	if (address % sizeof(writeBuffer) == 0)
 		nextWriteAddress = address;
 #else
 	// Only consecutive writes are supported

--- a/bootloader.cpp
+++ b/bootloader.cpp
@@ -68,6 +68,8 @@ constexpr const struct VersionInfoInFlash version_info __attribute__((__section_
 	BL_VERSION,
 };
 
+uint8_t info_hw_type{INFO_HW_TYPE};
+
 struct __attribute__((packed)) ApplicationStartupArguments {
     uint8_t modbus_address;
 };
@@ -247,7 +249,7 @@ cmd_result processCommand(uint8_t cmd, uint8_t *datain, uint8_t len, uint8_t *da
 
 			// Type 42 dwarf or type 43 modular bed
 			static_assert(sizeof(INFO_HW_TYPE) == sizeof(uint8_t), "INFO_HW_TYPE won't fit to 1 byte!");
-			dataout[0] = INFO_HW_TYPE;
+			dataout[0] = info_hw_type;  // Might be changed at runtime(prusa_baseboard) to reflect the actual board type(determined by resistors on GPIO pins)
 
 			// Hardware revision
 			uint16_t hardware_revision = get_revision();

--- a/bootloader.h
+++ b/bootloader.h
@@ -20,10 +20,17 @@
 
 #include <stdint.h>
 #include "otp.hpp"
+#include "Config.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Hardware type overwritable at runtime.
+ * Part of SL1SW-2927: "Add support for baseboard variants" - different
+ * variants of baseboard are determined by resistors connected to GPIO pins.
+ */
+extern uint8_t info_hw_type;
 
 void runBootloader();
 void ClockInit();

--- a/stm32-f4hal/Clock.cpp
+++ b/stm32-f4hal/Clock.cpp
@@ -12,7 +12,7 @@
 #include "stm32f4xx_hal_flash.h"
 #include "stm32f4xx_hal_flash_ex.h"
 
-#if defined(BOARD_TYPE_prusa_baseboard10)
+#if defined(BOARD_TYPE_prusa_baseboard)
     #define OSC_INIT_RCC_PLLM 6
     #define CLK_INIT_APB2CLKDivider RCC_HCLK_DIV4
 #elif defined(BOARD_TYPE_prusa_smartled01)

--- a/stm32-f4hal/Gpio.c
+++ b/stm32-f4hal/Gpio.c
@@ -21,30 +21,6 @@ void gpio_init() {
 
     /*Configure GPIO pin Output Level */
     #if defined(BOARD_TYPE_prusa_baseboard)
-        HAL_GPIO_WritePin(GPIOG, D_MCU_PWR_EN_Pin, GPIO_PIN_RESET);
-        HAL_GPIO_WritePin(GPIOG, D_LED_POWER_EN_Pin, GPIO_PIN_RESET);
-        HAL_GPIO_WritePin(GPIOB, D_LED_EN_Pin, GPIO_PIN_RESET);
-        HAL_GPIO_WritePin(GPIOB, D_POWER_OUT_EN_Pin, GPIO_PIN_RESET);
-        HAL_GPIO_WritePin(GPIOF, D_EXT_2_Pin, GPIO_PIN_RESET);
-
-        GPIO_InitStruct.Pin = D_MCU_PWR_EN_Pin | D_LED_POWER_EN_Pin | D_SECOND_RESET_Pin;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        HAL_GPIO_Init(GPIOG, &GPIO_InitStruct);
-
-        GPIO_InitStruct.Pin = D_LED_EN_Pin | D_POWER_OUT_EN_Pin | D_LED_RESET_Pin;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-
-        GPIO_InitStruct.Pin = D_EXT_2_Pin;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        HAL_GPIO_Init(GPIOF, &GPIO_InitStruct);
-
         // ID pins for baseboard variants
         GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
         GPIO_InitStruct.Pull = GPIO_PULLUP;
@@ -101,22 +77,3 @@ void gpio_init() {
 
     #endif
 }
-
-#if defined(BOARD_TYPE_prusa_baseboard)
-    void reset_fellow_slaves() {
-        HAL_GPIO_WritePin(D_SECOND_RESET_GPIO_Port, D_SECOND_RESET_Pin, GPIO_PIN_SET);
-        HAL_GPIO_WritePin(D_LED_RESET_GPIO_Port, 	D_LED_RESET_Pin, 	GPIO_PIN_SET);
-        HAL_Delay(100);
-        HAL_GPIO_WritePin(D_SECOND_RESET_GPIO_Port, D_SECOND_RESET_Pin, GPIO_PIN_RESET);
-        HAL_GPIO_WritePin(D_LED_RESET_GPIO_Port, 	D_LED_RESET_Pin, 	GPIO_PIN_RESET);
-    }
-
-    void turn_smartled_on() {
-        HAL_GPIO_WritePin(D_MCU_PWR_EN_GPIO_Port, D_MCU_PWR_EN_Pin, GPIO_PIN_RESET);
-        HAL_GPIO_WritePin(D_LED_EN_GPIO_Port, D_LED_EN_Pin, GPIO_PIN_SET);
-        HAL_GPIO_WritePin(D_LED_POWER_EN_GPIO_Port, D_LED_POWER_EN_Pin, GPIO_PIN_SET);
-        HAL_GPIO_WritePin(D_POWER_OUT_EN_GPIO_Port, D_POWER_OUT_EN_Pin, GPIO_PIN_SET);
-        HAL_GPIO_WritePin(D_EXT_2_GPIO_Port, D_EXT_2_Pin, GPIO_PIN_RESET);
-        reset_fellow_slaves();
-    }
-#endif

--- a/stm32-f4hal/Gpio.c
+++ b/stm32-f4hal/Gpio.c
@@ -2,6 +2,9 @@
 
 #include "stm32f4xx.h"
 #include "stm32f4xx_hal_gpio.h"
+#include <stdint.h>
+
+extern uint8_t info_hw_type;
 
 void gpio_init() {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
@@ -41,6 +44,42 @@ void gpio_init() {
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         HAL_GPIO_Init(GPIOF, &GPIO_InitStruct);
+
+        // ID pins for baseboard variants
+        GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+        GPIO_InitStruct.Pull = GPIO_PULLUP;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Pin = D_SLX_ID_Pin;
+        HAL_GPIO_Init(D_SLX_ID_GPIO_Port, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+        GPIO_InitStruct.Pull = GPIO_PULLUP;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Pin = D_CX_ID_Pin;
+        HAL_GPIO_Init(D_CX_ID_GPIO_Port, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+        GPIO_InitStruct.Pull = GPIO_PULLUP;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Pin = D_WX_ID_Pin;
+        HAL_GPIO_Init(D_WX_ID_GPIO_Port, &GPIO_InitStruct);
+
+        // Determine the baseboard type based on ID pins
+        GPIO_PinState is_slx = HAL_GPIO_ReadPin(D_SLX_ID_GPIO_Port, D_SLX_ID_Pin);
+        GPIO_PinState is_cx = HAL_GPIO_ReadPin(D_CX_ID_GPIO_Port, D_CX_ID_Pin);
+        GPIO_PinState is_wx = HAL_GPIO_ReadPin(D_WX_ID_GPIO_Port, D_WX_ID_Pin);
+
+        if (is_slx == GPIO_PIN_RESET) {
+            info_hw_type = 53; // Baseboard SLX variant
+        } else if (is_cx == GPIO_PIN_RESET) {
+            info_hw_type = 54; // Baseboard CX variant
+        } else if (is_wx == GPIO_PIN_RESET) {
+            info_hw_type = 55; // Baseboard WX variant
+        } else {
+            info_hw_type = 51; // Baseboard unknown, use default
+        }
+
+
 
     #elif defined(BOARD_TYPE_prusa_smartled01)
         HAL_GPIO_WritePin(GPIOB, D_LED_EN_Pin, GPIO_PIN_RESET);

--- a/stm32-f4hal/Gpio.c
+++ b/stm32-f4hal/Gpio.c
@@ -17,7 +17,7 @@ void gpio_init() {
     __HAL_RCC_GPIOD_CLK_ENABLE();
 
     /*Configure GPIO pin Output Level */
-    #if defined(BOARD_TYPE_prusa_baseboard10)
+    #if defined(BOARD_TYPE_prusa_baseboard)
         HAL_GPIO_WritePin(GPIOG, D_MCU_PWR_EN_Pin, GPIO_PIN_RESET);
         HAL_GPIO_WritePin(GPIOG, D_LED_POWER_EN_Pin, GPIO_PIN_RESET);
         HAL_GPIO_WritePin(GPIOB, D_LED_EN_Pin, GPIO_PIN_RESET);
@@ -63,7 +63,7 @@ void gpio_init() {
     #endif
 }
 
-#if defined(BOARD_TYPE_prusa_baseboard10)
+#if defined(BOARD_TYPE_prusa_baseboard)
     void reset_fellow_slaves() {
         HAL_GPIO_WritePin(D_SECOND_RESET_GPIO_Port, D_SECOND_RESET_Pin, GPIO_PIN_SET);
         HAL_GPIO_WritePin(D_LED_RESET_GPIO_Port, 	D_LED_RESET_Pin, 	GPIO_PIN_SET);

--- a/stm32-f4hal/Gpio.h
+++ b/stm32-f4hal/Gpio.h
@@ -3,21 +3,6 @@
 #include "stm32f4xx_hal_gpio.h"
 
 #if defined(BOARD_TYPE_prusa_baseboard)
-    #define D_MCU_PWR_EN_Pin GPIO_PIN_0
-    #define D_MCU_PWR_EN_GPIO_Port GPIOG
-    #define D_LED_POWER_EN_Pin GPIO_PIN_1
-    #define D_LED_POWER_EN_GPIO_Port GPIOG
-    #define D_LED_RESET_Pin GPIO_PIN_8
-    #define D_LED_RESET_GPIO_Port GPIOB
-    #define D_LED_EN_Pin GPIO_PIN_9
-    #define D_LED_EN_GPIO_Port GPIOB
-    #define D_EXT_2_Pin GPIO_PIN_10
-    #define D_EXT_2_GPIO_Port GPIOF
-    #define D_POWER_OUT_EN_Pin GPIO_PIN_12
-    #define D_POWER_OUT_EN_GPIO_Port GPIOB
-    #define D_SECOND_RESET_Pin GPIO_PIN_7
-    #define D_SECOND_RESET_GPIO_Port GPIOG
-
     // ID pins for baseboard variants
     #define D_SLX_ID_GPIO_Port GPIOA
     #define D_SLX_ID_Pin GPIO_PIN_12
@@ -44,10 +29,6 @@
 extern "C" {
 #endif
 void gpio_init();
-#if defined(BOARD_TYPE_prusa_baseboard)
-    void reset_fellow_slaves();
-    void turn_smartled_on();
-#endif
 
 #ifdef __cplusplus
 }

--- a/stm32-f4hal/Gpio.h
+++ b/stm32-f4hal/Gpio.h
@@ -3,7 +3,7 @@
 #include "stm32f4xx_hal_gpio.h"
 
 
-#if defined(BOARD_TYPE_prusa_baseboard10)
+#if defined(BOARD_TYPE_prusa_baseboard)
     #define D_MCU_PWR_EN_Pin GPIO_PIN_0
     #define D_MCU_PWR_EN_GPIO_Port GPIOG
     #define D_LED_POWER_EN_Pin GPIO_PIN_1
@@ -38,7 +38,7 @@
 extern "C" {
 #endif
 void gpio_init();
-#if defined(BOARD_TYPE_prusa_baseboard10)
+#if defined(BOARD_TYPE_prusa_baseboard)
     void reset_fellow_slaves();
     void turn_smartled_on();
 #endif

--- a/stm32-f4hal/Gpio.h
+++ b/stm32-f4hal/Gpio.h
@@ -2,7 +2,6 @@
 #include "stm32f4xx.h"
 #include "stm32f4xx_hal_gpio.h"
 
-
 #if defined(BOARD_TYPE_prusa_baseboard)
     #define D_MCU_PWR_EN_Pin GPIO_PIN_0
     #define D_MCU_PWR_EN_GPIO_Port GPIOG
@@ -18,6 +17,15 @@
     #define D_POWER_OUT_EN_GPIO_Port GPIOB
     #define D_SECOND_RESET_Pin GPIO_PIN_7
     #define D_SECOND_RESET_GPIO_Port GPIOG
+
+    // ID pins for baseboard variants
+    #define D_SLX_ID_GPIO_Port GPIOA
+    #define D_SLX_ID_Pin GPIO_PIN_12
+    #define D_CX_ID_GPIO_Port GPIOG
+    #define D_CX_ID_Pin GPIO_PIN_8
+    #define D_WX_ID_GPIO_Port GPIOG
+    #define D_WX_ID_Pin GPIO_PIN_9
+
 #elif defined(BOARD_TYPE_prusa_smartled01)
     #define D_P5V_PWR_EN_Pin GPIO_PIN_9
     #define D_P5V_PWR_EN_GPIO_Port GPIOA // ON! (or blinking?)
@@ -31,8 +39,6 @@
 #else
     #error "Undefined pin definitopm"
 #endif
-
-
 
 #ifdef __cplusplus
 extern "C" {

--- a/stm32-f4hal/Gpio.h
+++ b/stm32-f4hal/Gpio.h
@@ -23,11 +23,11 @@
     #define D_P5V_PWR_EN_GPIO_Port GPIOA // ON! (or blinking?)
     #define D_LED_EN_Pin GPIO_PIN_15
     #define D_LED_EN_GPIO_Port GPIOB // OFF!
-    /* 
+    /*
      * TODO (Nemec): Add fans to be turned on during bootup!
      * FAN1
      * FAN2
-    */ 
+    */
 #else
     #error "Undefined pin definitopm"
 #endif

--- a/stm32-f4hal/Rs485.cpp
+++ b/stm32-f4hal/Rs485.cpp
@@ -14,7 +14,7 @@
 #include <cstring>
 #include <cassert>
 
-#if defined(BOARD_TYPE_prusa_baseboard10)
+#if defined(BOARD_TYPE_prusa_baseboard)
     #include "Gpio.h"
     #define D_RS485_FLOW_CONTROL_Pin LL_GPIO_PIN_4
     #define D_RS485_FLOW_CONTROL_GPIO_Port GPIOD
@@ -90,7 +90,7 @@ void BusInit() {
     LL_USART_ConfigAsyncMode(USART_CHANNEL);
     LL_USART_Enable(USART_CHANNEL);
 
-    #if defined(BOARD_TYPE_prusa_baseboard10)
+    #if defined(BOARD_TYPE_prusa_baseboard)
         turn_smartled_on();
     #endif
 }

--- a/stm32-f4hal/Rs485.cpp
+++ b/stm32-f4hal/Rs485.cpp
@@ -89,10 +89,6 @@ void BusInit() {
     // TODO: Timeout is implemented in BusUpdate() function.
     LL_USART_ConfigAsyncMode(USART_CHANNEL);
     LL_USART_Enable(USART_CHANNEL);
-
-    #if defined(BOARD_TYPE_prusa_baseboard)
-        turn_smartled_on();
-    #endif
 }
 
 void BusDeinit() {

--- a/stm32-f4hal/stm32f4xx_hal_conf.h
+++ b/stm32-f4hal/stm32f4xx_hal_conf.h
@@ -96,7 +96,7 @@
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
 #if !defined  (HSE_VALUE)
-  #if defined(BOARD_TYPE_prusa_baseboard10)
+  #if defined(BOARD_TYPE_prusa_baseboard)
       #define HSE_VALUE    12000000U /*!< Value of the External oscillator in Hz */
   #elif defined(BOARD_TYPE_prusa_smartled01)
       #define HSE_VALUE    24000000U


### PR DESCRIPTION
Support for hardware identification by GPIO pins + other changes relevant for baseboard15 and newer. Baseboard10 is obsolete.